### PR TITLE
java 7 compat: stop using named capturing groups :(

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
   - python: 3.6-dev
   - python: pypy3
   - language: java
-    jdk: oraclejdk7
   include:
   - python: 3.5
   - python: 3.4

--- a/java/src/org/netpreserve/urlcanon/CharSequences.java
+++ b/java/src/org/netpreserve/urlcanon/CharSequences.java
@@ -56,13 +56,4 @@ class CharSequences {
             return input.subSequence(start, matcher.end(group));
         }
     }
-
-    static ByteString group(ByteString input, Matcher matcher, String group) {
-        int start = matcher.start(group);
-        if (start == -1) {
-            return ByteString.EMPTY;
-        } else {
-            return input.subSequence(start, matcher.end(group));
-        }
-    }
 }


### PR DESCRIPTION
Java 7 doesn't support Matcher.start(name) and Matcher.end(name) for named groups and we can't just use Matcher.group(name) as that would convert our ByteString to a String. So this change replaces all the named capturing groups with integer indices. :cry:

@yetti can you try setting version 17c1cfc in your pom and let me know if this solves your build problem?