### PR TITLE
remove nested repetitions from pathish in URL_REGEX (#5)

### DIFF
--- a/java/src/org/netpreserve/urlcanon/ParsedUrl.java
+++ b/java/src/org/netpreserve/urlcanon/ParsedUrl.java
@@ -38,9 +38,7 @@ public class ParsedUrl {
             "   ( [a-zA-Z] [^:]* )" + // SCHEME
             "   ( : )" + // COLON_AFTER_SCHEME
             ")?" +
-            "(" + // PATHISH
-            "  (?: [/\\\\]* [^/\\\\?#]* )*" +
-            ")" +
+            "( [^?#]* )" + // PATHISH
             "(?:" +
             "  ( [?] )" + // QUESTION_MARK
             "  ( [^#]* )" + // QUERY

--- a/python/urlcanon/parse.py
+++ b/python/urlcanon/parse.py
@@ -34,9 +34,7 @@ URL_REGEX = re.compile(br'''
    (?P<scheme> [a-zA-Z] [^:]* )
    (?P<colon_after_scheme> : )
 )?
-(?P<pathish>
-  ( [/\\]* [^/\\?#]* )*
-)
+(?P<pathish> [^?#]* )
 (?:
   (?P<question_mark> [?] )
   (?P<query> [^#]* )


### PR DESCRIPTION
Nested repetitions can parsed in an enormous number of different ways causing pathological behaviour (near infinite loops and stack overflows) from the regex engine.

We simplify the expression to `[^?#]*` which should match the exact same set of strings as the nested expression anyway.