### PR TITLE
Add the ability to fetch a list of SURT parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 /urlcanon.egg-info
 __pycache__
 /.cache
+*.py[co]
+build
+.eggs
+.pytest_cache
+venv

--- a/python/tests/test_urlcanon.py
+++ b/python/tests/test_urlcanon.py
@@ -201,7 +201,7 @@ def test_parsing(input, parsed_fields):
     assert parsed_url.hash_sign == parsed_fields[b'hash_sign']
     assert parsed_url.fragment == parsed_fields[b'fragment']
     assert parsed_url.trailing_junk == parsed_fields[b'trailing_junk']
-    assert parsed_url.get_surt_parts() == parsed_fields[b'parts']
+    assert parsed_url.surt_ancestry() == parsed_fields[b'parts']
 
 
 def load_supplemental_whatwg_test_data():

--- a/python/tests/test_urlcanon.py
+++ b/python/tests/test_urlcanon.py
@@ -201,7 +201,7 @@ def test_parsing(input, parsed_fields):
     assert parsed_url.hash_sign == parsed_fields[b'hash_sign']
     assert parsed_url.fragment == parsed_fields[b'fragment']
     assert parsed_url.trailing_junk == parsed_fields[b'trailing_junk']
-    assert parsed_url.surt_ancestry() == parsed_fields[b'parts']
+    assert parsed_url.surt_ancestry() == parsed_fields[b'surt_ancestry']
 
 
 def load_supplemental_whatwg_test_data():

--- a/python/tests/test_urlcanon.py
+++ b/python/tests/test_urlcanon.py
@@ -201,6 +201,8 @@ def test_parsing(input, parsed_fields):
     assert parsed_url.hash_sign == parsed_fields[b'hash_sign']
     assert parsed_url.fragment == parsed_fields[b'fragment']
     assert parsed_url.trailing_junk == parsed_fields[b'trailing_junk']
+    assert parsed_url.get_surt_parts() == parsed_fields[b'parts']
+
 
 def load_supplemental_whatwg_test_data():
     path = os.path.join(

--- a/python/urlcanon/parse.py
+++ b/python/urlcanon/parse.py
@@ -161,7 +161,7 @@ class ParsedUrl:
                 + self.hash_sign + self.fragment + self.trailing_junk)
         return result
 
-    def get_surt_parts(self):
+    def surt_ancestry(self):
         # For now, we only support SURT parts for certain cases.
         if self.scheme not in urlcanon.SPECIAL_SCHEMES.keys():
             return []
@@ -181,21 +181,21 @@ class ParsedUrl:
             # incomplete hosts
             # (e.g: http://(com,examle) and http://(com,example )
             if self.port:
-                parts.append(b':' + self.port + b')')
+                parts.append(self.colon_before_port + self.port + b')')
             else:
                 parts.append(b')')
-        for part in self.path.split(b'/'):
-            if part != b'':
-                parts.append(b'/' + part)
+        # Remove initial b'' which appears due to leading slash on the path.
+        path_parts = self.path.split(b'/')
+        if path_parts[0] == b'':
+            path_parts.remove(b'')
+        for part in path_parts:
+            parts.append(b'/' + part)
         if self.query:
             parts.append(self.question_mark + self.query)
         if self.fragment:
             parts.append(self.hash_sign + self.fragment)
         if self.trailing_junk:
             parts.append(self.trailing_junk)
-
-        # Strip empty parts.
-        parts = [part for part in parts if part != b'']
 
         # Build a list of SURT fragments.
         while parts != []:

--- a/testdata/parsing.json
+++ b/testdata/parsing.json
@@ -247,9 +247,10 @@
     "trailing_junk": "",
     "username": "",
     "parts": [
-      "file:/\n//a/b/c",
-      "file:/\n//a/b",
-      "file:/\n//a",
+      "file:/\n///a/b/c",
+      "file:/\n///a/b",
+      "file:/\n///a",
+      "file:/\n//",
       "file:/\n/"
     ]
   },
@@ -356,9 +357,10 @@
     "trailing_junk": "",
     "username": "",
     "parts": [
-      "file:///a/b/c",
-      "file:///a/b",
-      "file:///a",
+      "file:////a/b/c",
+      "file:////a/b",
+      "file:////a",
+      "file:///",
       "file://"
     ]
   },
@@ -466,9 +468,10 @@
     "trailing_junk": "",
     "username": "",
     "parts": [
-      "file:/\\/a/b/c",
-      "file:/\\/a/b",
-      "file:/\\/a",
+      "file:/\\//a/b/c",
+      "file:/\\//a/b",
+      "file:/\\//a",
+      "file:/\\/",
       "file:/\\"
     ]
   },
@@ -601,9 +604,10 @@
     "trailing_junk": "",
     "username": "",
     "parts": [
-      "file:\\//a/b/c",
-      "file:\\//a/b",
-      "file:\\//a",
+      "file:\\///a/b/c",
+      "file:\\///a/b",
+      "file:\\///a",
+      "file:\\//",
       "file:\\/"
     ]
   },
@@ -1008,6 +1012,35 @@
     "username": "",
     "parts": [
       "http://(a,)/b/c",
+      "http://(a,)/b",
+      "http://(a,)",
+      "http://(a,",
+      "http://("
+    ]
+  },
+  "http://a/b//c": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "a",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/b//c",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "parts": [
+      "http://(a,)/b//c",
+      "http://(a,)/b/",
       "http://(a,)/b",
       "http://(a,)",
       "http://(a,",

--- a/testdata/parsing.json
+++ b/testdata/parsing.json
@@ -1,4 +1,448 @@
 {
+  "http://example.com": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,)",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://example.com/test": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,)/test",
+      "http://(com,example,)",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://example.com/test?a=b": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "a=b",
+    "question_mark": "?",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,)/test?a=b",
+      "http://(com,example,)/test",
+      "http://(com,example,)",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://example.com/test#x": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "x",
+    "hash_sign": "#",
+    "host": "example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,)/test#x",
+      "http://(com,example,)/test",
+      "http://(com,example,)",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://example.com/test?a=b#x": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "x",
+    "hash_sign": "#",
+    "host": "example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "a=b",
+    "question_mark": "?",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,)/test?a=b#x",
+      "http://(com,example,)/test?a=b",
+      "http://(com,example,)/test",
+      "http://(com,example,)",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://subdomain.example.com": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,)",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://subdomain.example.com/test": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,)/test",
+      "http://(com,example,subdomain,)",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://subdomain.example.com/test?a=b": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "a=b",
+    "question_mark": "?",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,)/test?a=b",
+      "http://(com,example,subdomain,)/test",
+      "http://(com,example,subdomain,)",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://subdomain.example.com/test#x": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "x",
+    "hash_sign": "#",
+    "host": "subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,)/test#x",
+      "http://(com,example,subdomain,)/test",
+      "http://(com,example,subdomain,)",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://subdomain.example.com/test?a=b#x": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "x",
+    "hash_sign": "#",
+    "host": "subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "a=b",
+    "question_mark": "?",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,)/test?a=b#x",
+      "http://(com,example,subdomain,)/test?a=b",
+      "http://(com,example,subdomain,)/test",
+      "http://(com,example,subdomain,)",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://sub.subdomain.example.com": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "sub.subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,sub,)",
+      "http://(com,example,subdomain,sub,",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://sub.subdomain.example.com/test": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "sub.subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,sub,)/test",
+      "http://(com,example,subdomain,sub,)",
+      "http://(com,example,subdomain,sub,",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://sub.subdomain.example.com/test?a=b": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "",
+    "hash_sign": "",
+    "host": "sub.subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "a=b",
+    "question_mark": "?",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,sub,)/test?a=b",
+      "http://(com,example,subdomain,sub,)/test",
+      "http://(com,example,subdomain,sub,)",
+      "http://(com,example,subdomain,sub,",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://sub.subdomain.example.com/test#x": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "x",
+    "hash_sign": "#",
+    "host": "sub.subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "",
+    "question_mark": "",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,sub,)/test#x",
+      "http://(com,example,subdomain,sub,)/test",
+      "http://(com,example,subdomain,sub,)",
+      "http://(com,example,subdomain,sub,",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
+  "http://sub.subdomain.example.com/test?a=b#x": {
+    "at_sign": "",
+    "colon_after_scheme": ":",
+    "colon_before_password": "",
+    "colon_before_port": "",
+    "fragment": "x",
+    "hash_sign": "#",
+    "host": "sub.subdomain.example.com",
+    "ip4": null,
+    "ip6": null,
+    "leading_junk": "",
+    "password": "",
+    "path": "/test",
+    "port": "",
+    "query": "a=b",
+    "question_mark": "?",
+    "scheme": "http",
+    "slashes": "//",
+    "trailing_junk": "",
+    "username": "",
+    "surt_ancestry": [
+      "http://(com,example,subdomain,sub,)/test?a=b#x",
+      "http://(com,example,subdomain,sub,)/test?a=b",
+      "http://(com,example,subdomain,sub,)/test",
+      "http://(com,example,subdomain,sub,)",
+      "http://(com,example,subdomain,sub,",
+      "http://(com,example,subdomain,",
+      "http://(com,example,",
+      "http://(com,",
+      "http://("
+    ]
+  },
   "about:blank#x": {
     "at_sign": "",
     "colon_after_scheme": ":",
@@ -19,7 +463,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "\tHt\ntp\t:": {
     "at_sign": "",
@@ -41,7 +485,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "\tNon\nspecial\t:": {
     "at_sign": "",
@@ -63,7 +507,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "\tfi\nle\t:": {
     "at_sign": "",
@@ -85,7 +529,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   " f\ti\nle\t:": {
     "at_sign": "",
@@ -107,7 +551,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   " h\tT\nTp\t:": {
     "at_sign": "",
@@ -129,7 +573,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   " n\tO\nNspecial\t:": {
     "at_sign": "",
@@ -151,7 +595,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "fi\nle:": {
     "at_sign": "",
@@ -173,7 +617,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "file:": {
     "at_sign": "",
@@ -195,7 +639,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:"
     ]
   },
@@ -219,7 +663,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/\na/b/c",
       "file:/\na/b",
       "file:/\na",
@@ -246,7 +690,7 @@
     "slashes": "/\n/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/\n///a/b/c",
       "file:/\n///a/b",
       "file:/\n///a",
@@ -274,7 +718,7 @@
     "slashes": "/\n/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/\n//a/b/c",
       "file:/\n//a/b",
       "file:/\n//a",
@@ -301,7 +745,7 @@
     "slashes": "/\n/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/\n/(a,)/b/c",
       "file:/\n/(a,)/b",
       "file:/\n/(a,)",
@@ -329,7 +773,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/\na/b/c",
       "file:/\na/b",
       "file:/\na",
@@ -356,7 +800,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:////a/b/c",
       "file:////a/b",
       "file:////a",
@@ -384,7 +828,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:///a/b/c",
       "file:///a/b",
       "file:///a",
@@ -411,7 +855,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file://(a,)/b/c",
       "file://(a,)/b",
       "file://(a,)",
@@ -439,7 +883,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file://(x:y@a:8000,)/b/c",
       "file://(x:y@a:8000,)/b",
       "file://(x:y@a:8000,)",
@@ -467,7 +911,7 @@
     "slashes": "/\\",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/\\//a/b/c",
       "file:/\\//a/b",
       "file:/\\//a",
@@ -495,7 +939,7 @@
     "slashes": "/\\",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/\\/a/b/c",
       "file:/\\/a/b",
       "file:/\\/a",
@@ -522,7 +966,7 @@
     "slashes": "/\\",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/\\(a,)/b/c",
       "file:/\\(a,)/b",
       "file:/\\(a,)",
@@ -550,7 +994,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/a/b/c",
       "file:/a/b",
       "file:/a",
@@ -577,7 +1021,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/a\\b/c",
       "file:/a\\b",
       "file:"
@@ -603,7 +1047,7 @@
     "slashes": "\\/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:\\///a/b/c",
       "file:\\///a/b",
       "file:\\///a",
@@ -631,7 +1075,7 @@
     "slashes": "\\/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:\\//a/b/c",
       "file:\\//a/b",
       "file:\\//a",
@@ -658,7 +1102,7 @@
     "slashes": "\\/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:\\/(a,)/b/c",
       "file:\\/(a,)/b",
       "file:\\/(a,)",
@@ -686,7 +1130,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/\\a/b/c",
       "file:/\\a/b",
       "file:/\\a",
@@ -713,7 +1157,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/a/b/c",
       "file:/a/b",
       "file:/a",
@@ -740,7 +1184,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "http:": {
     "at_sign": "",
@@ -762,7 +1206,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:"
     ]
   },
@@ -786,7 +1230,7 @@
     "slashes": "\n",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:\n(a,)/b/c",
       "http:\n(a,)/b",
       "http:\n(a,)",
@@ -814,7 +1258,7 @@
     "slashes": "/\n///",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:/\n///(a,)/b/c",
       "http:/\n///(a,)/b",
       "http:/\n///(a,)",
@@ -842,7 +1286,7 @@
     "slashes": "/\n//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:/\n//(a,)/b/c",
       "http:/\n//(a,)/b",
       "http:/\n//(a,)",
@@ -870,7 +1314,7 @@
     "slashes": "/\n/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:/\n/(a,)/b/c",
       "http:/\n/(a,)/b",
       "http:/\n/(a,)",
@@ -898,7 +1342,7 @@
     "slashes": "/\n",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:/\n(a,)/b/c",
       "http:/\n(a,)/b",
       "http:/\n(a,)",
@@ -926,7 +1370,7 @@
     "slashes": "////",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:////(a,)/b/c",
       "http:////(a,)/b",
       "http:////(a,)",
@@ -954,7 +1398,7 @@
     "slashes": "///",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:///(a,)/b/c",
       "http:///(a,)/b",
       "http:///(a,)",
@@ -982,7 +1426,7 @@
     "slashes": "///",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:///(a,:8000)/b/c",
       "http:///(a,:8000)/b",
       "http:///(a,:8000)",
@@ -1010,7 +1454,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http://(a,)/b/c",
       "http://(a,)/b",
       "http://(a,)",
@@ -1038,7 +1482,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http://(a,)/b//c",
       "http://(a,)/b/",
       "http://(a,)/b",
@@ -1067,7 +1511,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http://(a,:8000)/b/c",
       "http://(a,:8000)/b",
       "http://(a,:8000)",
@@ -1095,7 +1539,7 @@
     "slashes": "/\\//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:/\\//(a,)/b/c",
       "http:/\\//(a,)/b",
       "http:/\\//(a,)",
@@ -1123,7 +1567,7 @@
     "slashes": "/\\/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:/\\/(a,)/b/c",
       "http:/\\/(a,)/b",
       "http:/\\/(a,)",
@@ -1151,7 +1595,7 @@
     "slashes": "/\\/",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:/\\/(a,:8000)/b/c",
       "http:/\\/(a,:8000)/b",
       "http:/\\/(a,:8000)",
@@ -1179,7 +1623,7 @@
     "slashes": "/\\",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:/\\(a,)/b/c",
       "http:/\\(a,)/b",
       "http:/\\(a,)",
@@ -1207,7 +1651,7 @@
     "slashes": "/\\",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:/\\(a,:8000)/b/c",
       "http:/\\(a,:8000)/b",
       "http:/\\(a,:8000)",
@@ -1235,7 +1679,7 @@
     "slashes": "/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:/(a,)/b/c",
       "http:/(a,)/b",
       "http:/(a,)",
@@ -1263,7 +1707,7 @@
     "slashes": "/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:/(a,)/\\b/c",
       "http:/(a,)/\\b",
       "http:/(a,)",
@@ -1291,7 +1735,7 @@
     "slashes": "/",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:/(a,:8000)/b/c",
       "http:/(a,:8000)/b",
       "http:/(a,:8000)",
@@ -1319,7 +1763,7 @@
     "slashes": "\\///",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:\\///(a,)/b/c",
       "http:\\///(a,)/b",
       "http:\\///(a,)",
@@ -1347,7 +1791,7 @@
     "slashes": "\\//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:\\//(a,)/b/c",
       "http:\\//(a,)/b",
       "http:\\//(a,)",
@@ -1375,7 +1819,7 @@
     "slashes": "\\//",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:\\//(a,:8000)/b/c",
       "http:\\//(a,:8000)/b",
       "http:\\//(a,:8000)",
@@ -1403,7 +1847,7 @@
     "slashes": "\\/",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:\\/(a,)/b/c",
       "http:\\/(a,)/b",
       "http:\\/(a,)",
@@ -1431,7 +1875,7 @@
     "slashes": "\\/",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:\\/(a,:8000)/b/c",
       "http:\\/(a,:8000)/b",
       "http:\\/(a,:8000)",
@@ -1459,7 +1903,7 @@
     "slashes": "\\",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:\\(a,)/b/c",
       "http:\\(a,)/b",
       "http:\\(a,)",
@@ -1487,7 +1931,7 @@
     "slashes": "\\",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:\\(a,:8000)/b/c",
       "http:\\(a,:8000)/b",
       "http:\\(a,:8000)",
@@ -1515,7 +1959,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "http:(a,)/b/c",
       "http:(a,)/b",
       "http:(a,)",
@@ -1543,7 +1987,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:(a,:8000)/b/c",
       "http:(a,:8000)/b",
       "http:(a,:8000)",
@@ -1571,7 +2015,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:\na/b/c": {
     "at_sign": "",
@@ -1593,7 +2037,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/\n///a/b/c": {
     "at_sign": "",
@@ -1615,7 +2059,7 @@
     "slashes": "/\n/",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/\n//a/b/c": {
     "at_sign": "",
@@ -1637,7 +2081,7 @@
     "slashes": "/\n/",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/\n/a/b/c": {
     "at_sign": "",
@@ -1659,7 +2103,7 @@
     "slashes": "/\n/",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/\na/b/c": {
     "at_sign": "",
@@ -1681,7 +2125,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:////a/b/c": {
     "at_sign": "",
@@ -1703,7 +2147,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:///a/b/c": {
     "at_sign": "",
@@ -1725,7 +2169,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:///x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1747,7 +2191,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial://a/b/c": {
     "at_sign": "",
@@ -1769,7 +2213,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial://x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -1791,7 +2235,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "x",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/\\//a/b/c": {
     "at_sign": "",
@@ -1813,7 +2257,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/\\/a/b/c": {
     "at_sign": "",
@@ -1835,7 +2279,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/\\/x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1857,7 +2301,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/\\a/b/c": {
     "at_sign": "",
@@ -1879,7 +2323,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/\\x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1901,7 +2345,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/a/b/c": {
     "at_sign": "",
@@ -1923,7 +2367,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/a\\b/c": {
     "at_sign": "",
@@ -1945,7 +2389,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1967,7 +2411,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:\\///a/b/c": {
     "at_sign": "",
@@ -1989,7 +2433,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:\\//a/b/c": {
     "at_sign": "",
@@ -2011,7 +2455,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:\\//x:y@a:8000/b/c": {
     "at_sign": "",
@@ -2033,7 +2477,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:\\/a/b/c": {
     "at_sign": "",
@@ -2055,7 +2499,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:\\/x:y@a:8000/b/c": {
     "at_sign": "",
@@ -2077,7 +2521,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:\\a/b/c": {
     "at_sign": "",
@@ -2099,7 +2543,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:\\x:y@a:8000/b/c": {
     "at_sign": "",
@@ -2121,7 +2565,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:a/b/c": {
     "at_sign": "",
@@ -2143,7 +2587,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:x:y@a:8000/b/c": {
     "at_sign": "",
@@ -2165,7 +2609,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000a\u000b\u000c\u000d\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f\u0020\u0021\u0022\u0023\u0024\u0025\u0026\u0027\u0028\u0029\u002a\u002b\u002c\u002d\u002e\u002f\u0030\u0031\u0032\u0033\u0034\u0035\u0036\u0037\u0038\u0039\u003a\u003b\u003c\u003d\u003e\u003f\u0040\u0041\u0042\u0043\u0044\u0045\u0046\u0047\u0048\u0049\u004a\u004b\u004c\u004d\u004e\u004f\u0050\u0051\u0052\u0053\u0054\u0055\u0056\u0057\u0058\u0059\u005a\u005b\u005c\u005d\u005e\u005f\u0060\u0061\u0062\u0063\u0064\u0065\u0066\u0067\u0068\u0069\u006a\u006b\u006c\u006d\u006e\u006f\u0070\u0071\u0072\u0073\u0074\u0075\u0076\u0077\u0078\u0079\u007a\u007b\u007c\u007d\u007e\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008a\u008b\u008c\u008d\u008e\u008f\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f\u00a0\u00a1\u00a2\u00a3\u00a4\u00a5\u00a6\u00a7\u00a8\u00a9\u00aa\u00ab\u00ac\u00ad\u00ae\u00af\u00b0\u00b1\u00b2\u00b3\u00b4\u00b5\u00b6\u00b7\u00b8\u00b9\u00ba\u00bb\u00bc\u00bd\u00be\u00bf\u00c0\u00c1\u00c2\u00c3\u00c4\u00c5\u00c6\u00c7\u00c8\u00c9\u00ca\u00cb\u00cc\u00cd\u00ce\u00cf\u00d0\u00d1\u00d2\u00d3\u00d4\u00d5\u00d6\u00d7\u00d8\u00d9\u00da\u00db\u00dc\u00dd\u00de\u00df\u00e0\u00e1\u00e2\u00e3\u00e4\u00e5\u00e6\u00e7\u00e8\u00e9\u00ea\u00eb\u00ec\u00ed\u00ee\u00ef\u00f0\u00f1\u00f2\u00f3\u00f4\u00f5\u00f6\u00f7\u00f8\u00f9\u00fa\u00fb\u00fc\u00fd\u00fe\u00ff": {
     "at_sign": "",
@@ -2187,7 +2631,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "http:x:y@a:8000": {
     "at_sign": "@",
@@ -2209,7 +2653,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:(a,:8000)",
       "http:(a,",
       "http:("
@@ -2235,7 +2679,7 @@
     "slashes": "/",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http:/(a,:8000)",
       "http:/(a,",
       "http:/("
@@ -2261,7 +2705,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "x",
-    "parts": [
+    "surt_ancestry": [
       "http://(a,:8000)",
       "http://(a,",
       "http://("
@@ -2287,7 +2731,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/x:y@a:8000",
       "file:"
     ]
@@ -2312,7 +2756,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file:/x:y@a:8000",
       "file:"
     ]
@@ -2337,7 +2781,7 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "",
-    "parts": [
+    "surt_ancestry": [
       "file://(x:y@a:8000,)",
       "file://(x:y@a:8000,",
       "file://("
@@ -2363,7 +2807,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial:/x:y@a:8000": {
     "at_sign": "",
@@ -2385,7 +2829,7 @@
     "slashes": "",
     "trailing_junk": "",
     "username": "",
-    "parts": []
+    "surt_ancestry": []
   },
   "nonspecial://x:y@a:8000": {
     "at_sign": "@",
@@ -2407,6 +2851,6 @@
     "slashes": "//",
     "trailing_junk": "",
     "username": "x",
-    "parts": []
+    "surt_ancestry": []
   }
 }

--- a/testdata/parsing.json
+++ b/testdata/parsing.json
@@ -18,7 +18,8 @@
     "scheme": "about",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "\tHt\ntp\t:": {
     "at_sign": "",
@@ -39,7 +40,8 @@
     "scheme": "Ht\ntp\t",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "\tNon\nspecial\t:": {
     "at_sign": "",
@@ -60,7 +62,8 @@
     "scheme": "Non\nspecial\t",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "\tfi\nle\t:": {
     "at_sign": "",
@@ -81,7 +84,8 @@
     "scheme": "fi\nle\t",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   " f\ti\nle\t:": {
     "at_sign": "",
@@ -102,7 +106,8 @@
     "scheme": "f\ti\nle\t",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   " h\tT\nTp\t:": {
     "at_sign": "",
@@ -123,7 +128,8 @@
     "scheme": "h\tT\nTp\t",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   " n\tO\nNspecial\t:": {
     "at_sign": "",
@@ -144,7 +150,8 @@
     "scheme": "n\tO\nNspecial\t",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "fi\nle:": {
     "at_sign": "",
@@ -165,7 +172,8 @@
     "scheme": "fi\nle",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "file:": {
     "at_sign": "",
@@ -186,7 +194,10 @@
     "scheme": "file",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:"
+    ]
   },
   "file:\na/b/c": {
     "at_sign": "",
@@ -207,7 +218,13 @@
     "scheme": "file",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/\na/b/c",
+      "file:/\na/b",
+      "file:/\na",
+      "file:"
+    ]
   },
   "file:/\n///a/b/c": {
     "at_sign": "",
@@ -228,7 +245,13 @@
     "scheme": "file",
     "slashes": "/\n/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/\n//a/b/c",
+      "file:/\n//a/b",
+      "file:/\n//a",
+      "file:/\n/"
+    ]
   },
   "file:/\n//a/b/c": {
     "at_sign": "",
@@ -249,7 +272,13 @@
     "scheme": "file",
     "slashes": "/\n/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/\n//a/b/c",
+      "file:/\n//a/b",
+      "file:/\n//a",
+      "file:/\n/"
+    ]
   },
   "file:/\n/a/b/c": {
     "at_sign": "",
@@ -270,7 +299,14 @@
     "scheme": "file",
     "slashes": "/\n/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/\n/(a,)/b/c",
+      "file:/\n/(a,)/b",
+      "file:/\n/(a,)",
+      "file:/\n/(a,",
+      "file:/\n/("
+    ]
   },
   "file:/\na/b/c": {
     "at_sign": "",
@@ -291,7 +327,13 @@
     "scheme": "file",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/\na/b/c",
+      "file:/\na/b",
+      "file:/\na",
+      "file:"
+    ]
   },
   "file:////a/b/c": {
     "at_sign": "",
@@ -312,7 +354,13 @@
     "scheme": "file",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:///a/b/c",
+      "file:///a/b",
+      "file:///a",
+      "file://"
+    ]
   },
   "file:///a/b/c": {
     "at_sign": "",
@@ -333,7 +381,13 @@
     "scheme": "file",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:///a/b/c",
+      "file:///a/b",
+      "file:///a",
+      "file://"
+    ]
   },
   "file://a/b/c": {
     "at_sign": "",
@@ -354,7 +408,14 @@
     "scheme": "file",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file://(a,)/b/c",
+      "file://(a,)/b",
+      "file://(a,)",
+      "file://(a,",
+      "file://("
+    ]
   },
   "file://x:y@a:8000/b/c": {
     "at_sign": "",
@@ -375,7 +436,14 @@
     "scheme": "file",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file://(x:y@a:8000,)/b/c",
+      "file://(x:y@a:8000,)/b",
+      "file://(x:y@a:8000,)",
+      "file://(x:y@a:8000,",
+      "file://("
+    ]
   },
   "file:/\\//a/b/c": {
     "at_sign": "",
@@ -396,7 +464,13 @@
     "scheme": "file",
     "slashes": "/\\",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/\\/a/b/c",
+      "file:/\\/a/b",
+      "file:/\\/a",
+      "file:/\\"
+    ]
   },
   "file:/\\/a/b/c": {
     "at_sign": "",
@@ -417,7 +491,13 @@
     "scheme": "file",
     "slashes": "/\\",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/\\/a/b/c",
+      "file:/\\/a/b",
+      "file:/\\/a",
+      "file:/\\"
+    ]
   },
   "file:/\\a/b/c": {
     "at_sign": "",
@@ -438,7 +518,14 @@
     "scheme": "file",
     "slashes": "/\\",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/\\(a,)/b/c",
+      "file:/\\(a,)/b",
+      "file:/\\(a,)",
+      "file:/\\(a,",
+      "file:/\\("
+    ]
   },
   "file:/a/b/c": {
     "at_sign": "",
@@ -459,7 +546,13 @@
     "scheme": "file",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/a/b/c",
+      "file:/a/b",
+      "file:/a",
+      "file:"
+    ]
   },
   "file:/a\\b/c": {
     "at_sign": "",
@@ -480,7 +573,12 @@
     "scheme": "file",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/a\\b/c",
+      "file:/a\\b",
+      "file:"
+    ]
   },
   "file:\\///a/b/c": {
     "at_sign": "",
@@ -501,7 +599,13 @@
     "scheme": "file",
     "slashes": "\\/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:\\//a/b/c",
+      "file:\\//a/b",
+      "file:\\//a",
+      "file:\\/"
+    ]
   },
   "file:\\//a/b/c": {
     "at_sign": "",
@@ -522,7 +626,13 @@
     "scheme": "file",
     "slashes": "\\/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:\\//a/b/c",
+      "file:\\//a/b",
+      "file:\\//a",
+      "file:\\/"
+    ]
   },
   "file:\\/a/b/c": {
     "at_sign": "",
@@ -543,7 +653,14 @@
     "scheme": "file",
     "slashes": "\\/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:\\/(a,)/b/c",
+      "file:\\/(a,)/b",
+      "file:\\/(a,)",
+      "file:\\/(a,",
+      "file:\\/("
+    ]
   },
   "file:\\a/b/c": {
     "at_sign": "",
@@ -564,7 +681,13 @@
     "scheme": "file",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/\\a/b/c",
+      "file:/\\a/b",
+      "file:/\\a",
+      "file:"
+    ]
   },
   "file:a/b/c": {
     "at_sign": "",
@@ -585,7 +708,13 @@
     "scheme": "file",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/a/b/c",
+      "file:/a/b",
+      "file:/a",
+      "file:"
+    ]
   },
   "ht\nTP:": {
     "at_sign": "",
@@ -606,7 +735,8 @@
     "scheme": "ht\nTP",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "http:": {
     "at_sign": "",
@@ -627,7 +757,10 @@
     "scheme": "http",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:"
+    ]
   },
   "http:\na/b/c": {
     "at_sign": "",
@@ -648,7 +781,14 @@
     "scheme": "http",
     "slashes": "\n",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:\n(a,)/b/c",
+      "http:\n(a,)/b",
+      "http:\n(a,)",
+      "http:\n(a,",
+      "http:\n("
+    ]
   },
   "http:/\n///a/b/c": {
     "at_sign": "",
@@ -669,7 +809,14 @@
     "scheme": "http",
     "slashes": "/\n///",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:/\n///(a,)/b/c",
+      "http:/\n///(a,)/b",
+      "http:/\n///(a,)",
+      "http:/\n///(a,",
+      "http:/\n///("
+    ]
   },
   "http:/\n//a/b/c": {
     "at_sign": "",
@@ -690,7 +837,14 @@
     "scheme": "http",
     "slashes": "/\n//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:/\n//(a,)/b/c",
+      "http:/\n//(a,)/b",
+      "http:/\n//(a,)",
+      "http:/\n//(a,",
+      "http:/\n//("
+    ]
   },
   "http:/\n/a/b/c": {
     "at_sign": "",
@@ -711,7 +865,14 @@
     "scheme": "http",
     "slashes": "/\n/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:/\n/(a,)/b/c",
+      "http:/\n/(a,)/b",
+      "http:/\n/(a,)",
+      "http:/\n/(a,",
+      "http:/\n/("
+    ]
   },
   "http:/\na/b/c": {
     "at_sign": "",
@@ -732,7 +893,14 @@
     "scheme": "http",
     "slashes": "/\n",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:/\n(a,)/b/c",
+      "http:/\n(a,)/b",
+      "http:/\n(a,)",
+      "http:/\n(a,",
+      "http:/\n("
+    ]
   },
   "http:////a/b/c": {
     "at_sign": "",
@@ -753,7 +921,14 @@
     "scheme": "http",
     "slashes": "////",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:////(a,)/b/c",
+      "http:////(a,)/b",
+      "http:////(a,)",
+      "http:////(a,",
+      "http:////("
+    ]
   },
   "http:///a/b/c": {
     "at_sign": "",
@@ -774,7 +949,14 @@
     "scheme": "http",
     "slashes": "///",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:///(a,)/b/c",
+      "http:///(a,)/b",
+      "http:///(a,)",
+      "http:///(a,",
+      "http:///("
+    ]
   },
   "http:///x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -795,7 +977,14 @@
     "scheme": "http",
     "slashes": "///",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:///(a,:8000)/b/c",
+      "http:///(a,:8000)/b",
+      "http:///(a,:8000)",
+      "http:///(a,",
+      "http:///("
+    ]
   },
   "http://a/b/c": {
     "at_sign": "",
@@ -816,7 +1005,14 @@
     "scheme": "http",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http://(a,)/b/c",
+      "http://(a,)/b",
+      "http://(a,)",
+      "http://(a,",
+      "http://("
+    ]
   },
   "http://x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -837,7 +1033,14 @@
     "scheme": "http",
     "slashes": "//",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http://(a,:8000)/b/c",
+      "http://(a,:8000)/b",
+      "http://(a,:8000)",
+      "http://(a,",
+      "http://("
+    ]
   },
   "http:/\\//a/b/c": {
     "at_sign": "",
@@ -858,7 +1061,14 @@
     "scheme": "http",
     "slashes": "/\\//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:/\\//(a,)/b/c",
+      "http:/\\//(a,)/b",
+      "http:/\\//(a,)",
+      "http:/\\//(a,",
+      "http:/\\//("
+    ]
   },
   "http:/\\/a/b/c": {
     "at_sign": "",
@@ -879,7 +1089,14 @@
     "scheme": "http",
     "slashes": "/\\/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:/\\/(a,)/b/c",
+      "http:/\\/(a,)/b",
+      "http:/\\/(a,)",
+      "http:/\\/(a,",
+      "http:/\\/("
+    ]
   },
   "http:/\\/x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -900,7 +1117,14 @@
     "scheme": "http",
     "slashes": "/\\/",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:/\\/(a,:8000)/b/c",
+      "http:/\\/(a,:8000)/b",
+      "http:/\\/(a,:8000)",
+      "http:/\\/(a,",
+      "http:/\\/("
+    ]
   },
   "http:/\\a/b/c": {
     "at_sign": "",
@@ -921,7 +1145,14 @@
     "scheme": "http",
     "slashes": "/\\",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:/\\(a,)/b/c",
+      "http:/\\(a,)/b",
+      "http:/\\(a,)",
+      "http:/\\(a,",
+      "http:/\\("
+    ]
   },
   "http:/\\x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -942,7 +1173,14 @@
     "scheme": "http",
     "slashes": "/\\",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:/\\(a,:8000)/b/c",
+      "http:/\\(a,:8000)/b",
+      "http:/\\(a,:8000)",
+      "http:/\\(a,",
+      "http:/\\("
+    ]
   },
   "http:/a/b/c": {
     "at_sign": "",
@@ -963,7 +1201,14 @@
     "scheme": "http",
     "slashes": "/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:/(a,)/b/c",
+      "http:/(a,)/b",
+      "http:/(a,)",
+      "http:/(a,",
+      "http:/("
+    ]
   },
   "http:/a\\b/c": {
     "at_sign": "",
@@ -984,7 +1229,14 @@
     "scheme": "http",
     "slashes": "/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:/(a,)/\\b/c",
+      "http:/(a,)/\\b",
+      "http:/(a,)",
+      "http:/(a,",
+      "http:/("
+    ]
   },
   "http:/x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -1005,7 +1257,14 @@
     "scheme": "http",
     "slashes": "/",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:/(a,:8000)/b/c",
+      "http:/(a,:8000)/b",
+      "http:/(a,:8000)",
+      "http:/(a,",
+      "http:/("
+    ]
   },
   "http:\\///a/b/c": {
     "at_sign": "",
@@ -1026,7 +1285,14 @@
     "scheme": "http",
     "slashes": "\\///",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:\\///(a,)/b/c",
+      "http:\\///(a,)/b",
+      "http:\\///(a,)",
+      "http:\\///(a,",
+      "http:\\///("
+    ]
   },
   "http:\\//a/b/c": {
     "at_sign": "",
@@ -1047,7 +1313,14 @@
     "scheme": "http",
     "slashes": "\\//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:\\//(a,)/b/c",
+      "http:\\//(a,)/b",
+      "http:\\//(a,)",
+      "http:\\//(a,",
+      "http:\\//("
+    ]
   },
   "http:\\//x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -1068,7 +1341,14 @@
     "scheme": "http",
     "slashes": "\\//",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:\\//(a,:8000)/b/c",
+      "http:\\//(a,:8000)/b",
+      "http:\\//(a,:8000)",
+      "http:\\//(a,",
+      "http:\\//("
+    ]
   },
   "http:\\/a/b/c": {
     "at_sign": "",
@@ -1089,7 +1369,14 @@
     "scheme": "http",
     "slashes": "\\/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:\\/(a,)/b/c",
+      "http:\\/(a,)/b",
+      "http:\\/(a,)",
+      "http:\\/(a,",
+      "http:\\/("
+    ]
   },
   "http:\\/x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -1110,7 +1397,14 @@
     "scheme": "http",
     "slashes": "\\/",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:\\/(a,:8000)/b/c",
+      "http:\\/(a,:8000)/b",
+      "http:\\/(a,:8000)",
+      "http:\\/(a,",
+      "http:\\/("
+    ]
   },
   "http:\\a/b/c": {
     "at_sign": "",
@@ -1131,7 +1425,14 @@
     "scheme": "http",
     "slashes": "\\",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:\\(a,)/b/c",
+      "http:\\(a,)/b",
+      "http:\\(a,)",
+      "http:\\(a,",
+      "http:\\("
+    ]
   },
   "http:\\x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -1152,7 +1453,14 @@
     "scheme": "http",
     "slashes": "\\",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:\\(a,:8000)/b/c",
+      "http:\\(a,:8000)/b",
+      "http:\\(a,:8000)",
+      "http:\\(a,",
+      "http:\\("
+    ]
   },
   "http:a/b/c": {
     "at_sign": "",
@@ -1173,7 +1481,14 @@
     "scheme": "http",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "http:(a,)/b/c",
+      "http:(a,)/b",
+      "http:(a,)",
+      "http:(a,",
+      "http:("
+    ]
   },
   "http:x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -1194,7 +1509,14 @@
     "scheme": "http",
     "slashes": "",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:(a,:8000)/b/c",
+      "http:(a,:8000)/b",
+      "http:(a,:8000)",
+      "http:(a,",
+      "http:("
+    ]
   },
   "non\nSPeciAL:": {
     "at_sign": "",
@@ -1215,7 +1537,8 @@
     "scheme": "non\nSPeciAL",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:\na/b/c": {
     "at_sign": "",
@@ -1236,7 +1559,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/\n///a/b/c": {
     "at_sign": "",
@@ -1257,7 +1581,8 @@
     "scheme": "nonspecial",
     "slashes": "/\n/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/\n//a/b/c": {
     "at_sign": "",
@@ -1278,7 +1603,8 @@
     "scheme": "nonspecial",
     "slashes": "/\n/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/\n/a/b/c": {
     "at_sign": "",
@@ -1299,7 +1625,8 @@
     "scheme": "nonspecial",
     "slashes": "/\n/",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/\na/b/c": {
     "at_sign": "",
@@ -1320,7 +1647,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:////a/b/c": {
     "at_sign": "",
@@ -1341,7 +1669,8 @@
     "scheme": "nonspecial",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:///a/b/c": {
     "at_sign": "",
@@ -1362,7 +1691,8 @@
     "scheme": "nonspecial",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:///x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1383,7 +1713,8 @@
     "scheme": "nonspecial",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial://a/b/c": {
     "at_sign": "",
@@ -1404,7 +1735,8 @@
     "scheme": "nonspecial",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial://x:y@a:8000/b/c": {
     "at_sign": "@",
@@ -1425,7 +1757,8 @@
     "scheme": "nonspecial",
     "slashes": "//",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": []
   },
   "nonspecial:/\\//a/b/c": {
     "at_sign": "",
@@ -1446,7 +1779,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/\\/a/b/c": {
     "at_sign": "",
@@ -1467,7 +1801,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/\\/x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1488,7 +1823,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/\\a/b/c": {
     "at_sign": "",
@@ -1509,7 +1845,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/\\x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1530,7 +1867,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/a/b/c": {
     "at_sign": "",
@@ -1551,7 +1889,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/a\\b/c": {
     "at_sign": "",
@@ -1572,7 +1911,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1593,7 +1933,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:\\///a/b/c": {
     "at_sign": "",
@@ -1614,7 +1955,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:\\//a/b/c": {
     "at_sign": "",
@@ -1635,7 +1977,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:\\//x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1656,7 +1999,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:\\/a/b/c": {
     "at_sign": "",
@@ -1677,7 +2021,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:\\/x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1698,7 +2043,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:\\a/b/c": {
     "at_sign": "",
@@ -1719,7 +2065,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:\\x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1740,7 +2087,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:a/b/c": {
     "at_sign": "",
@@ -1761,7 +2109,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:x:y@a:8000/b/c": {
     "at_sign": "",
@@ -1782,7 +2131,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000a\u000b\u000c\u000d\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f\u0020\u0021\u0022\u0023\u0024\u0025\u0026\u0027\u0028\u0029\u002a\u002b\u002c\u002d\u002e\u002f\u0030\u0031\u0032\u0033\u0034\u0035\u0036\u0037\u0038\u0039\u003a\u003b\u003c\u003d\u003e\u003f\u0040\u0041\u0042\u0043\u0044\u0045\u0046\u0047\u0048\u0049\u004a\u004b\u004c\u004d\u004e\u004f\u0050\u0051\u0052\u0053\u0054\u0055\u0056\u0057\u0058\u0059\u005a\u005b\u005c\u005d\u005e\u005f\u0060\u0061\u0062\u0063\u0064\u0065\u0066\u0067\u0068\u0069\u006a\u006b\u006c\u006d\u006e\u006f\u0070\u0071\u0072\u0073\u0074\u0075\u0076\u0077\u0078\u0079\u007a\u007b\u007c\u007d\u007e\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008a\u008b\u008c\u008d\u008e\u008f\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f\u00a0\u00a1\u00a2\u00a3\u00a4\u00a5\u00a6\u00a7\u00a8\u00a9\u00aa\u00ab\u00ac\u00ad\u00ae\u00af\u00b0\u00b1\u00b2\u00b3\u00b4\u00b5\u00b6\u00b7\u00b8\u00b9\u00ba\u00bb\u00bc\u00bd\u00be\u00bf\u00c0\u00c1\u00c2\u00c3\u00c4\u00c5\u00c6\u00c7\u00c8\u00c9\u00ca\u00cb\u00cc\u00cd\u00ce\u00cf\u00d0\u00d1\u00d2\u00d3\u00d4\u00d5\u00d6\u00d7\u00d8\u00d9\u00da\u00db\u00dc\u00dd\u00de\u00df\u00e0\u00e1\u00e2\u00e3\u00e4\u00e5\u00e6\u00e7\u00e8\u00e9\u00ea\u00eb\u00ec\u00ed\u00ee\u00ef\u00f0\u00f1\u00f2\u00f3\u00f4\u00f5\u00f6\u00f7\u00f8\u00f9\u00fa\u00fb\u00fc\u00fd\u00fe\u00ff": {
     "at_sign": "",
@@ -1803,7 +2153,8 @@
     "scheme": "",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "http:x:y@a:8000": {
     "at_sign": "@",
@@ -1824,7 +2175,12 @@
     "scheme": "http",
     "slashes": "",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:(a,:8000)",
+      "http:(a,",
+      "http:("
+    ]
   },
   "http:/x:y@a:8000": {
     "at_sign": "@",
@@ -1845,7 +2201,12 @@
     "scheme": "http",
     "slashes": "/",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http:/(a,:8000)",
+      "http:/(a,",
+      "http:/("
+    ]
   },
   "http://x:y@a:8000": {
     "at_sign": "@",
@@ -1866,7 +2227,12 @@
     "scheme": "http",
     "slashes": "//",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": [
+      "http://(a,:8000)",
+      "http://(a,",
+      "http://("
+    ]
   },
   "file:x:y@a:8000": {
     "at_sign": "",
@@ -1887,7 +2253,11 @@
     "scheme": "file",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/x:y@a:8000",
+      "file:"
+    ]
   },
   "file:/x:y@a:8000": {
     "at_sign": "",
@@ -1908,7 +2278,11 @@
     "scheme": "file",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file:/x:y@a:8000",
+      "file:"
+    ]
   },
   "file://x:y@a:8000": {
     "at_sign": "",
@@ -1929,7 +2303,12 @@
     "scheme": "file",
     "slashes": "//",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": [
+      "file://(x:y@a:8000,)",
+      "file://(x:y@a:8000,",
+      "file://("
+    ]
   },
   "nonspecial:x:y@a:8000": {
     "at_sign": "",
@@ -1950,7 +2329,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial:/x:y@a:8000": {
     "at_sign": "",
@@ -1971,7 +2351,8 @@
     "scheme": "nonspecial",
     "slashes": "",
     "trailing_junk": "",
-    "username": ""
+    "username": "",
+    "parts": []
   },
   "nonspecial://x:y@a:8000": {
     "at_sign": "@",
@@ -1992,6 +2373,7 @@
     "scheme": "nonspecial",
     "slashes": "//",
     "trailing_junk": "",
-    "username": "x"
+    "username": "x",
+    "parts": []
   }
 }


### PR DESCRIPTION
In some situations, it may be desirable to get a list of what makes up a SURT, i.e:

* http://(com,example,)/a/b
* http://(com,example,)/a
* http://(com,example,)
* http://(com,example,
* http://(com,
* http://(

`get_surt_parts` builds this list and returns it to the user.