### PR TITLE
Add ability to use stricter conditions in MatchRule 

### DIFF
--- a/python/tests/test_match_rules.py
+++ b/python/tests/test_match_rules.py
@@ -27,6 +27,13 @@ def test_match_rules():
     assert not rule.applies('http://example.com/foo/baz')
 
     rule = urlcanon.MatchRule(
+        surt=urlcanon.semantic(b'http://example.com/foo/bar').surt(), exact=True)
+    assert not rule.applies('hTTp://EXAmple.com.../FOo/Bar#zuh')
+    assert rule.applies('http://example.com/foo/bar')
+    assert not rule.applies('http://example.com/foo/baz')
+    assert not rule.applies('http://example.com/foo/bar/baz')
+
+    rule = urlcanon.MatchRule(
             ssurt=urlcanon.semantic(b'http://example.com/foo/bar').ssurt())
     assert not rule.applies('hTTp://EXAmple.com.../FOo/Bar#zuh')
     assert rule.applies(b'http://example.com/foo/bar')
@@ -71,6 +78,17 @@ def test_match_rules():
     assert not rule.applies('https://twitter.com/twit?lang=en')
     assert rule.applies('https://twitter.com/twit?lang=es')
 
+    rule = urlcanon.MatchRule(domain=b'example.com')
+    assert not rule.applies('https://twitter.com')
+    assert rule.applies('https://example.com')
+    assert rule.applies('https://abc.example.com')
+
+    rule = urlcanon.MatchRule(domain=b'example.com', exact=True)
+    assert not rule.applies('https://twitter.com')
+    assert rule.applies('https://example.com')
+    assert not rule.applies('https://abc.example.com')
+
+
 def test_url_matches_domain():
     assert urlcanon.url_matches_domain('http://1.2.3.4/', '1.2.3.4')
     assert urlcanon.url_matches_domain(b'scheme://1.2.3.4', '1.2.3.4')
@@ -93,6 +111,30 @@ def test_url_matches_domain():
             urlcanon.whatwg('https://😬.☃.net'),
             urlcanon.normalize_host('☃.net'))
 
+
+def test_url_matches_domain_exactly():
+    assert urlcanon.url_matches_domain_exactly('http://1.2.3.4/', '1.2.3.4')
+    assert urlcanon.url_matches_domain_exactly(b'scheme://1.2.3.4', '1.2.3.4')
+    assert urlcanon.url_matches_domain_exactly('ftp://1.2.3.4/a/b/c/d', b'1.2.3.4')
+    assert urlcanon.url_matches_domain_exactly(b'http://1.2.3.4', b'1.2.3.4')
+    assert not urlcanon.url_matches_domain_exactly(
+        'http://foo.example.com', 'example.com')
+    assert not urlcanon.url_matches_domain_exactly(
+        'http://example.com', 'foo.example.com')
+    assert not urlcanon.url_matches_domain_exactly(
+        'http://foo.EXAMPLE.COM', 'example.com')
+    assert not urlcanon.url_matches_domain_exactly(
+        urlcanon.whatwg('http://foo.EXAMPLE.COM'), 'example.com')
+    assert not urlcanon.url_matches_domain_exactly('http://☃.net', 'xn--n3h.net')
+    assert urlcanon.url_matches_domain_exactly('http://☃.net', '☃.net')
+    assert not urlcanon.url_matches_domain_exactly('http://😬.☃.net', '☃.net')
+    assert not urlcanon.url_matches_domain_exactly(
+        'http://😬.☃.net', urlcanon.normalize_host('☃.net'))
+    assert not urlcanon.url_matches_domain_exactly(
+        urlcanon.whatwg('https://😬.☃.net'),
+        urlcanon.normalize_host('☃.net'))
+
+
 def test_host_matches_domain():
     assert urlcanon.host_matches_domain('1.2.3.4', '1.2.3.4')
     assert urlcanon.host_matches_domain(b'1.2.3.4', '1.2.3.4')
@@ -112,3 +154,22 @@ def test_host_matches_domain():
             urlcanon.normalize_host('😬.☃.net'),
             urlcanon.normalize_host('☃.net'))
 
+
+def test_host_matches_domain_exactly():
+    assert urlcanon.host_matches_domain_exactly('1.2.3.4', '1.2.3.4')
+    assert urlcanon.host_matches_domain_exactly(b'1.2.3.4', '1.2.3.4')
+    assert urlcanon.host_matches_domain_exactly('1.2.3.4', b'1.2.3.4')
+    assert urlcanon.host_matches_domain_exactly(b'1.2.3.4', b'1.2.3.4')
+    assert not urlcanon.host_matches_domain_exactly('foo.example.com', 'example.com')
+    assert not urlcanon.host_matches_domain_exactly('example.com', 'foo.example.com')
+    assert not urlcanon.host_matches_domain_exactly('foo.EXAMPLE.COM', 'example.com')
+    assert not urlcanon.host_matches_domain_exactly(
+            urlcanon.normalize_host('foo.EXAMPLE.COM'), 'example.com')
+    assert not urlcanon.host_matches_domain_exactly('☃.net', 'xn--n3h.net')
+    assert urlcanon.host_matches_domain_exactly('☃.net', '☃.net')
+    assert not urlcanon.host_matches_domain_exactly('😬.☃.net', '☃.net')
+    assert not urlcanon.host_matches_domain_exactly(
+            '😬.☃.net', urlcanon.normalize_host('☃.net'))
+    assert not urlcanon.host_matches_domain_exactly(
+            urlcanon.normalize_host('😬.☃.net'),
+            urlcanon.normalize_host('☃.net'))

--- a/python/urlcanon/__init__.py
+++ b/python/urlcanon/__init__.py
@@ -20,13 +20,15 @@ from .parse import parse_url, ParsedUrl, parse_ipv4, parse_ipv4or6
 from .canon import (
         Canonicalizer, whatwg, google, semantic_precise, semantic, aggressive,
         normalize_host)
-from .rules import MatchRule, url_matches_domain, host_matches_domain
+from .rules import (
+        MatchRule, url_matches_domain, host_matches_domain,
+        url_matches_domain_exactly, host_matches_domain_exactly)
 
 __all__ = ['parse_url', 'ParsedUrl', 'parse_ipv4', 'parse_ipv4or6',
            'Canonicalizer', 'whatwg', 'google', 'semantic_precise', 'semantic',
            'MatchRule', 'SPECIAL_SCHEMES', 'reverse_host', 'ssurt_host',
-           'host_matches_domain', 'url_matches_domain', 'normalize_host',
-           'aggressive']
+           'host_matches_domain', 'url_matches_domain', 'host_matches_domain_exactly',
+           'host_matches_domain_exactly', 'normalize_host', 'aggressive']
 
 SPECIAL_SCHEMES = {
     b'ftp': b'21',


### PR DESCRIPTION
## Description

This PR adds the ability to use `MatchRule` for matching on `domain`, `surt`, and or `ssurt` exactly by
 - adding an exact condition modifier, applicable only to the aforementioned conditions
 - adding url_matches_domain_exactly and host_matches_domain_exactly methods for matching domains exactly

Tests have also been updated to cover these changes

## Motivation and Context

Currently when using a `MatchRule` configured with a `domain` condition the behavior is to allow subdomains 

https://github.com/iipc/urlcanon/blob/2ee55919f1f7f137318bd195957ef2270a47fee8/python/urlcanon/rules.py#L47-L53

Similarly, when the `MatchRule` is configured with `surt` and or `ssurt` the behavior would allow partial matching if configured with a value the would allow an partial match to be made

https://github.com/iipc/urlcanon/blob/2ee55919f1f7f137318bd195957ef2270a47fee8/python/urlcanon/rules.py#L202-L205

However there are use cases when it is desired to perform exact matches, for example, when accepting scoping rules for constraining a crawl to a particular domain excluding subdomains.

At webrecorder we use `MatchRule` for the crawl scope [use case](https://github.com/webrecorder/autobrowser/blob/frontier-scope-updates/autobrowser/scope/strict_rules.py) and felt that support for this use case best lived in urlcanon rather than in a downstream project. 
